### PR TITLE
Update linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           # Will parse the entire repository and find all files to validate across all types.
           # NOTE: When set to false, only new or edited files will be parsed for validation.
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           # The name of the repository default branch.
           DEFAULT_BRANCH: master
           # Flag to enable or disable the linting process of the Javascript language. (Utilizing: eslint)


### PR DESCRIPTION
In the linter.yml file set VALIDATE_ALL_CODEBASE: false.

When set to false, only new or edited files will be parsed for validation.

Closes #26