### PR TITLE
Fix greetings workflow failing

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set current month as env variable
-      run: echo "::set-env name=month::$(date '+%b')"
+      run: echo "month=$(date '+%b')" >> $GITHUB_ENV
     - uses: actions/first-interaction@v1
       if: env.month != 'Oct'
       with:


### PR DESCRIPTION
The `set-env` command that was being
used has been disabled. Upgraded to
using Environment Files.
More info on:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

Fixes #57